### PR TITLE
Fix : csrf 토큰 비활성화

### DIFF
--- a/backend/pitza/middleware.py
+++ b/backend/pitza/middleware.py
@@ -1,0 +1,9 @@
+class DisableCSRFMiddleware(object):
+
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        setattr(request, '_dont_enforce_csrf_checks', True)
+        response = self.get_response(request)
+        return response

--- a/backend/pitza/settings.py
+++ b/backend/pitza/settings.py
@@ -55,11 +55,10 @@ MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'corsheaders.middleware.CorsMiddleware',
+    'pitza.middleware.DisableCSRFMiddleware',
     'django.middleware.common.CommonMiddleware',
-    'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
-    'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
 ]
 
@@ -192,8 +191,8 @@ CORS_ALLOWED_ORIGINS = [
 # 세션/CSRF 쿠키 설정 (HTTP 사용 시 개발용)
 SESSION_COOKIE_SAMESITE = "Lax"
 SESSION_COOKIE_SECURE = False
-CSRF_COOKIE_SECURE = False
-SESSION_COOKIE_HTTPONLY = True
+SESSION_COOKIE_HTTPONLY = False
+
 
 # 배포 후 HTTPS 환경
 # SESSION_COOKIE_SAMESITE = "None"


### PR DESCRIPTION
## 문제
클라이언트에서 보내는 요청 중 서버의 csrf 관련 검증 로직이 제대로 검증을 못하는 문제가 있었습니다.

## 해결
CSRF의 경우 보안을 위해 설정하지만, 배포를 하지 않는 환경상 미들웨어를 추가해서 세션 방식에서 강제되는 csrf 설정을 비활성화 했습니다.

[참고자료](https://stackoverflow.com/questions/16458166/how-to-disable-djangos-csrf-validation)