### PR TITLE
refactor: 소켓 메세지 데이터 스네이크 케이스로 변경

### DIFF
--- a/backend/chat/templates/chat-test.html
+++ b/backend/chat/templates/chat-test.html
@@ -42,12 +42,12 @@
     const myUserId = 'me'
 
     function joinRoom() {
-      const roomId = document.getElementById('roomId').value;
-      if (!roomId) return alert("Room ID를 입력하세요.");
+      const room_id = document.getElementById('roomId').value;
+      if (!room_id) return alert("Room ID를 입력하세요.");
 
-      currentRoomId = roomId;
-      socket.emit('join', roomId);
-      appendMessage(`방 '${roomId}'에 참가했습니다`);
+      currentRoomId = room_id;
+      socket.emit('join', room_id);
+      appendMessage(`방 '${room_id}'에 참가했습니다`);
     }
 
     function sendText() {
@@ -55,12 +55,12 @@
       if (!message || !currentRoomId) return;
 
       const payload = {
-        roomId: currentRoomId,
-        userId: myUserId,
+        room_id: currentRoomId,
+        user_id: myUserId,
         message,
         timestamp: new Date().toISOString(),
-        messageType: 'text',
-        imageUrl: null,
+        message_type: 'text',
+        image_url: null,
         is_read: false
       };
 
@@ -80,12 +80,12 @@
         const base64Data = e.target.result.split(',')[1];
 
         const payload = {
-          roomId: currentRoomId,
-          userId: myUserId,
+          room_id: currentRoomId,
+          user_id: myUserId,
           message: null,
           timestamp: new Date().toISOString(),
-          messageType: 'image',
-          imageUrl: base64Data,
+          message_type: 'image',
+          image_url: base64Data,
           is_read: false
         };
 
@@ -115,13 +115,13 @@
     function renderOwnMessage(data) {
       // 수신 메시지와 동일 포맷 유지
       const dummyUserId = '[나]';
-      const { message, messageType, imageUrl, timestamp } = data;
+      const { message, message_type, image_url, timestamp } = data;
       let content = `<strong>${dummyUserId}</strong>: `;
 
-      if (messageType === 'text') {
+      if (message_type === 'text') {
         content += message;
-      } else if (messageType === 'image') {
-        const src = imageUrl.startsWith('http') ? imageUrl : `data:image/png;base64,${imageUrl}`;
+      } else if (message_type === 'image') {
+        const src = image_url.startsWith('http') ? image_url : `data:image/png;base64,${image_url}`;
         content += `[이미지]<br><img src="${src}" class="chat-image" />`;
       }
 
@@ -131,13 +131,13 @@
     }
 
     function renderMessage(data) {
-      const { userId, message, messageType, imageUrl, timestamp } = data;
-      let content = `<strong>사용자 ${userId}</strong>: `;
+      const { user_id, message, message_type, image_url, timestamp } = data;
+      let content = `<strong>사용자 ${user_id}</strong>: `;
 
-      if (messageType === 'text') {
+      if (message_type === 'text') {
         content += message;
-      } else if (messageType === 'image') {
-        content += `[이미지]<br><img src="${imageUrl}" class="chat-image" />`;
+      } else if (message_type === 'image') {
+        content += `[이미지]<br><img src="${image_url}" class="chat-image" />`;
       }
 
       const formattedTime = convertUTCToKST(timestamp);


### PR DESCRIPTION
다음과 같이 소켓 메세지 키 스네이크 케이스로 변경

1. 요청 페이로드
{
"room_id": "1",
"user_id": "me",
"message": "안녕하세요",
"timestamp": "2025-06-13T05:00:00.000Z",
"message_type": "text",
"image_url": null,
"is_read": false
}
2. 브로드캐스트 응답값
{
room_id: 6,
user_id: 1, 
message: 'test', 
timestamp: "2025-06-13 14:00:00”,
message_type: 'text', 
image_url: null,
is_read: false
}